### PR TITLE
handle a particular case where stage name is not defined

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ version in ThisBuild ~= (_ + s"_$akkaVersion")
 lazy val akkaVersion = Option(System.getProperty("akkaVersion")).getOrElse(defaultAkkaVersion)
 lazy val defaultAkkaVersion = "2.5.9"
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.7"
 lazy val gremlinVersion = "3.3.0"
 
 resolvers += "indvd00m-github-repo" at "https://raw.githubusercontent.com/indvd00m/maven-repo/master/repository"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.0
+sbt.version = 1.2.3

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -6,4 +6,7 @@ travesty {
         inlet  = "*INLET*"
         outlet = "*OUTLET*"
     }
+    render {
+        default-stage-name = "default stage name"
+    }
 }

--- a/src/main/scala/net/mikolak/travesty/VizGraphProcessor.scala
+++ b/src/main/scala/net/mikolak/travesty/VizGraphProcessor.scala
@@ -19,7 +19,8 @@ class VizGraphProcessor(typeNameSimplifier: TypeNameSimplifier) {
     def implOf(v: Vertex) = v.asScala.property(properties.node.StageImplementation).value()
 
     val implNames = in.V().l().foldRight(Map.empty[AkkaStage, String]) { (v, map) =>
-      val baseName = v.asScala.property(properties.node.StageName).value()
+      // @fixme default stage name might not be the best solution
+      val baseName = v.asScala.property(properties.node.StageName).orElse("default stage name")
       val impl     = implOf(v)
       if (map.contains(impl)) {
         map

--- a/src/main/scala/net/mikolak/travesty/VizGraphProcessor.scala
+++ b/src/main/scala/net/mikolak/travesty/VizGraphProcessor.scala
@@ -6,8 +6,9 @@ import gremlin.scala._
 import guru.nidi.graphviz.attribute.{MutableAttributed, Rank}
 import net.mikolak.travesty.properties.graph.GraphLabelKey
 import net.mikolak.travesty.render.TypeNameSimplifier
+import net.mikolak.travesty.setup.RenderConfig
 
-class VizGraphProcessor(typeNameSimplifier: TypeNameSimplifier) {
+class VizGraphProcessor(typeNameSimplifier: TypeNameSimplifier, renderConfig: RenderConfig) {
 
   import VizGraphProcessor._
 
@@ -19,8 +20,7 @@ class VizGraphProcessor(typeNameSimplifier: TypeNameSimplifier) {
     def implOf(v: Vertex) = v.asScala.property(properties.node.StageImplementation).value()
 
     val implNames = in.V().l().foldRight(Map.empty[AkkaStage, String]) { (v, map) =>
-      // @fixme default stage name might not be the best solution
-      val baseName = v.asScala.property(properties.node.StageName).orElse("default stage name")
+      val baseName = v.asScala.property(properties.node.StageName).orElse(renderConfig.defaultStageName)
       val impl     = implOf(v)
       if (map.contains(impl)) {
         map

--- a/src/main/scala/net/mikolak/travesty/setup/TravestyConfig.scala
+++ b/src/main/scala/net/mikolak/travesty/setup/TravestyConfig.scala
@@ -4,8 +4,15 @@ import scala.concurrent.duration.FiniteDuration
 
 private[travesty] case class TravestyConfig(cache: CacheConfig,
                                             engines: List[GraphvizEngineType.Value],
-                                            partialNames: PartialNamesConfig)
+                                            partialNames: PartialNamesConfig,
+                                            render: RenderConfig)
 
 private[travesty] case class CacheConfig(shapeCacheTtl: FiniteDuration)
 
 private[travesty] case class PartialNamesConfig(inlet: String, outlet: String)
+
+/**
+ *
+ * @param defaultStageName will be use whenever a stage name cannot be inferred
+ */
+private[travesty] case class RenderConfig(defaultStageName: String)

--- a/src/main/scala/net/mikolak/travesty/setup/Wiring.scala
+++ b/src/main/scala/net/mikolak/travesty/setup/Wiring.scala
@@ -18,6 +18,7 @@ private[travesty] object Wiring {
   import config.cache
   import config.engines
   import config.partialNames
+  import config.render
 
   lazy val registry                 = wire[Registry]
   lazy val akkaGraphCloser          = wire[AkkaGraphCloser]

--- a/src/test/scala/net/mikolak/travesty/VizGraphProcessorSpec.scala
+++ b/src/test/scala/net/mikolak/travesty/VizGraphProcessorSpec.scala
@@ -6,6 +6,7 @@ import guru.nidi.graphviz.model.{MutableGraph, Graph => VizGraph}
 import guru.nidi.graphviz.parse.Parser
 import net.mikolak.travesty
 import net.mikolak.travesty.render.TypeNameSimplifier
+import net.mikolak.travesty.setup.RenderConfig
 import org.scalatest.words.MustVerb
 import org.scalatest.{FlatSpec, MustMatchers}
 
@@ -14,7 +15,8 @@ import scala.reflect.runtime.universe._
 
 class VizGraphProcessorSpec extends FlatSpec with MustMatchers with MustVerb {
 
-  val testInst                                         = new VizGraphProcessor(new TypeNameSimplifier)
+  val defaultStageName                                 = "test-default-name"
+  val testInst                                         = new VizGraphProcessor(new TypeNameSimplifier, RenderConfig(defaultStageName))
   def tested[T <: AkkaStream: TypeTag](t: T): VizGraph = testInst.toVizGraph(travesty.toAbstractGraph(t))
 
   def calculateResult[T <: AkkaStream: TypeTag](t: T): MutableGraph = Parser.read(tested(t).toString)
@@ -108,6 +110,7 @@ class VizGraphProcessorSpec extends FlatSpec with MustMatchers with MustVerb {
 
     val output = calculateResult(input)
 
+    output.nodeList().map(_.label().toString) must contain (defaultStageName)
     output.nodeList() must have size 3
     output.linkList() must have size 2
   }

--- a/src/test/scala/net/mikolak/travesty/VizGraphProcessorSpec.scala
+++ b/src/test/scala/net/mikolak/travesty/VizGraphProcessorSpec.scala
@@ -101,6 +101,17 @@ class VizGraphProcessorSpec extends FlatSpec with MustMatchers with MustVerb {
       .map(_.toString)
   }
 
+  it must "support unnamed stages" in {
+    val input = Source.single("hello")
+      .log("logger")
+      .to(Sink.head)
+
+    val output = calculateResult(input)
+
+    output.nodeList() must have size 3
+    output.linkList() must have size 2
+  }
+
   implicit class MutGraphExtras(g: MutableGraph) {
 
     def nodeList() = g.nodes().asScala.toList


### PR DESCRIPTION
It seems that particular stages might not have a `name` attribute. When dealing with such streams, an exception is thrown in `VizGraphProcessor`. 

This PR fix this by adding a default stage name when such situations occurs.

Example of stream that would throw exception when generating diagram.

```scala
val myFlow = Source.single("hello")
      .log("logger")
      .to(Sink.head)
```

throw this exception 

> The property does not exist as it has no key, value, or associated element
java.lang.IllegalStateException: The property does not exist as it has no key, value, or associated element
	at org.apache.tinkerpop.gremlin.structure.Property$Exceptions.propertyDoesNotExist(Property.java:151)
	at org.apache.tinkerpop.gremlin.structure.util.empty.EmptyVertexProperty.value(EmptyVertexProperty.java:74)
	at net.mikolak.travesty.VizGraphProcessor.$anonfun$toVizGraph$1(VizGraphProcessor.scala:23)

I've added a test that validate the expected behavior.

Feel free to comment or criticize this fix :) 